### PR TITLE
Add `GetCoefficientsBytes` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ cargo run --example function_evaluation
 cargo run --example polynomial_evaluation
 cargo run --example simple_integers
 cargo run --example simple_real_numbers
+cargo run --example dcrt_poly
 ```
 
 # Contributing

--- a/examples/dcrt_poly.rs
+++ b/examples/dcrt_poly.rs
@@ -56,6 +56,9 @@ fn main() {
     let coeffs_poly_add = poly_add.GetCoefficients();
     println!("coeffs_poly_add: {:?}", coeffs_poly_add);
 
+    let coeffs_poly_bytes = poly.GetCoefficientsBytes();
+    println!("coeffs_poly_bytes: {:?}", coeffs_poly_bytes);
+
     let poly_modulus = poly.GetModulus();
     assert_eq!(poly_modulus, modulus);
 

--- a/examples/dcrt_poly.rs
+++ b/examples/dcrt_poly.rs
@@ -61,11 +61,11 @@ fn main() {
     println!("coeffs_poly_bytes: {:?}", coeffs_poly_bytes);
 
     // decode coeff_poly_bytes
-    let decoded_coeffs = parse_coefficients_bytes(&coeffs_poly_bytes);
-    println!("decoded mod: {:?}", decoded_coeffs.last().unwrap());
+    let parsed_coefficients = parse_coefficients_bytes(&coeffs_poly_bytes);
+    println!("decoded mod: {:?}", parsed_coefficients.modulus);
     println!(
         "decoded coeffs: {:?}",
-        &decoded_coeffs[..decoded_coeffs.len() - 1]
+        parsed_coefficients.coefficients
     );
 
     let poly_modulus = poly.GetModulus();

--- a/examples/dcrt_poly.rs
+++ b/examples/dcrt_poly.rs
@@ -1,6 +1,7 @@
 use num_bigint::BigUint;
 use num_traits::Num;
 use openfhe::ffi::{self, GetMatrixElement};
+use openfhe::parse_coefficients_bytes;
 
 fn main() {
     let val = String::from("123456789099999");
@@ -58,6 +59,14 @@ fn main() {
 
     let coeffs_poly_bytes = poly.GetCoefficientsBytes();
     println!("coeffs_poly_bytes: {:?}", coeffs_poly_bytes);
+
+    // decode coeff_poly_bytes
+    let decoded_coeffs = parse_coefficients_bytes(&coeffs_poly_bytes);
+    println!("decoded mod: {:?}", decoded_coeffs.last().unwrap());
+    println!(
+        "decoded coeffs: {:?}",
+        &decoded_coeffs[..decoded_coeffs.len() - 1]
+    );
 
     let poly_modulus = poly.GetModulus();
     assert_eq!(poly_modulus, modulus);

--- a/src/DCRTPoly.cc
+++ b/src/DCRTPoly.cc
@@ -49,6 +49,34 @@ rust::Vec<rust::String> DCRTPoly::GetCoefficients() const
     return result;
 }
 
+rust::Vec<rust::u8> DCRTPoly::GetCoefficientsBytes() const
+{   
+    auto tempPoly = m_poly;
+    tempPoly.SetFormat(Format::COEFFICIENT);
+
+    lbcrypto::DCRTPoly::PolyLargeType polyLarge = tempPoly.CRTInterpolate();
+
+    const lbcrypto::BigVector &coeffs = polyLarge.GetValues();
+
+    // Serialize the coefficients to a binary format
+    std::stringstream ss;
+    lbcrypto::Serial::Serialize(coeffs, ss, lbcrypto::SerType::BINARY);
+    
+    // Get the binary data as a string
+    std::string serializedData = ss.str();
+    
+    // Convert to a rust::Vec<rust::u8>
+    rust::Vec<rust::u8> result;
+    result.reserve(serializedData.size());
+    
+    // Copy each byte from the serialized data to the result vector
+    for (size_t i = 0; i < serializedData.size(); ++i) {
+        result.push_back(static_cast<rust::u8>(static_cast<unsigned char>(serializedData[i])));
+    }
+
+    return result;
+}
+
 std::unique_ptr<DCRTPoly> DCRTPoly::Negate() const
 {
     return std::make_unique<DCRTPoly>(-m_poly);

--- a/src/DCRTPoly.h
+++ b/src/DCRTPoly.h
@@ -3,6 +3,7 @@
 #include "openfhe/core/lattice/hal/lat-backend.h"
 #include "rust/cxx.h"
 #include "openfhe/core/math/matrix.h"
+#include "openfhe/core/utils/serial.h"
 
 namespace openfhe
 {
@@ -23,6 +24,7 @@ public:
     [[nodiscard]] rust::String GetString() const;
     [[nodiscard]] bool IsEqual(const DCRTPoly& other) const noexcept;
     [[nodiscard]] rust::Vec<rust::String> GetCoefficients() const;
+    [[nodiscard]] rust::Vec<rust::u8> GetCoefficientsBytes() const;
     [[nodiscard]] rust::String GetModulus() const;
     [[nodiscard]] std::unique_ptr<DCRTPoly> Negate() const;
     [[nodiscard]] std::unique_ptr<Matrix> Decompose() const;

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -104,8 +104,10 @@ std::unique_ptr<Matrix> DCRTSquareMatTrapdoorGaussSamp(usint n, usint k, const M
 {
     lbcrypto::DCRTPoly::DggType dgg(sigma);
 
+    size_t d = U.GetCols(); // U is a square matrix
+
     double c = (base + 1) * sigma;
-    double s = lbcrypto::SPECTRAL_BOUND(n, k, base);
+    double s = lbcrypto::SPECTRAL_BOUND_D(n, k, base, d);
     lbcrypto::DCRTPoly::DggType dggLargeSigma(sqrt(s * s - c * c));
 
     auto result = lbcrypto::RLWETrapdoorUtility<lbcrypto::DCRTPoly>::GaussSampSquareMat(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,6 +729,7 @@ pub mod ffi
         fn GetString(self: &DCRTPoly) -> String;
         fn IsEqual(self: &DCRTPoly, other: &DCRTPoly) -> bool;
         fn GetCoefficients(self: &DCRTPoly) -> Vec<String>;
+        fn GetCoefficientsBytes(self: &DCRTPoly) -> Vec<u8>;
         fn GetModulus(self: &DCRTPoly) -> String;
         fn Negate(self: &DCRTPoly) -> UniquePtr<DCRTPoly>;
         fn Decompose(self: &DCRTPoly) -> UniquePtr<Matrix>;


### PR DESCRIPTION
The new method returns a polynomial in its encoded representation `Vec<u8>`. This is supposed to be more efficient that the `GetCoefficients` method which returns `Vec<String>`.  A supporting helper method `parse_coefficients_bytes` is being added to decode the bytes vector into `Vec<BigUint>`