### PR TITLE
`GetPublicMatrixElement` takes mutable reference to self

### DIFF
--- a/examples/dcrt_poly.rs
+++ b/examples/dcrt_poly.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigUint;
 use num_traits::Num;
-use openfhe::ffi::{self, GetMatrixElement};
+use openfhe::ffi::{self, GetMatrixElement, GetMatrixElementUnsafe};
 use openfhe::parse_coefficients_bytes;
 
 fn main() {
@@ -132,6 +132,9 @@ fn main() {
     let ncol = ffi::GetMatrixCols(&preimage);
 
     let dummy_poly = ffi::DCRTPolyGenFromDug(n, size, k_res);
-    let decomposed_poly = dummy_poly.Decompose();
-    let poly_0_0 = GetMatrixElement(&decomposed_poly, 0, 0);
+    let mut decomposed_poly_mat = dummy_poly.Decompose();
+    let poly_0_0 = GetMatrixElement(&decomposed_poly_mat, 0, 0);
+
+    // use the unsafe method if you don't need the matrix anymore
+    let poly_0_1 = GetMatrixElementUnsafe(decomposed_poly_mat.as_mut().unwrap(), 0, 1);
 }

--- a/src/DCRTPoly.cc
+++ b/src/DCRTPoly.cc
@@ -255,6 +255,15 @@ std::unique_ptr<DCRTPoly> GetMatrixElement(
     return std::make_unique<DCRTPoly>(std::move(copy));
 }
 
+std::unique_ptr<DCRTPoly> GetMatrixElementUnsafe(
+    Matrix& matrix, 
+    size_t row, 
+    size_t col)
+{   
+    return std::make_unique<DCRTPoly>(std::move(matrix(row, col)));
+}
+
+
 size_t GetMatrixRows(const Matrix& matrix)
 {
     return matrix.GetRows();

--- a/src/DCRTPoly.h
+++ b/src/DCRTPoly.h
@@ -95,6 +95,11 @@ void SetMatrixElement(
     size_t row, 
     size_t col);
 
+[[nodiscard]] std::unique_ptr<DCRTPoly> GetMatrixElementUnsafe(
+    Matrix& matrix, 
+    size_t row, 
+    size_t col);
+    
 size_t GetMatrixRows(const Matrix& matrix);
 size_t GetMatrixCols(const Matrix& matrix);
 } // openfhe

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -19,16 +19,6 @@ std::unique_ptr<Matrix> DCRTTrapdoor::GetPublicMatrix() const
     return std::make_unique<Matrix>(m_publicMatrix);
 }
 
-std::unique_ptr<DCRTPoly> DCRTTrapdoor::GetPublicMatrixElement(size_t row, size_t col) const
-{
-    if (row >= m_publicMatrix.GetRows() || col >= m_publicMatrix.GetCols()) {
-        return nullptr;
-    }
-    
-    lbcrypto::DCRTPoly copy = m_publicMatrix(row, col);
-    return std::make_unique<DCRTPoly>(std::move(copy));
-}
-
 // Generator functions
 std::unique_ptr<DCRTTrapdoor> DCRTTrapdoorGen(
     usint n, 

--- a/src/Trapdoor.h
+++ b/src/Trapdoor.h
@@ -21,7 +21,6 @@ public:
 
     [[nodiscard]] std::unique_ptr<RLWETrapdoorPair> GetTrapdoorPair() const;
     [[nodiscard]] std::unique_ptr<Matrix> GetPublicMatrix() const;
-    [[nodiscard]] std::unique_ptr<DCRTPoly> GetPublicMatrixElement(size_t row, size_t col) const;
 };
 
 // Generator functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,11 +1173,6 @@ pub mod ffi
     // Trapdoor
     unsafe extern "C++" {
         fn GetPublicMatrix(self: &DCRTTrapdoor) -> UniquePtr<Matrix>;
-        fn GetPublicMatrixElement(
-            self: &DCRTTrapdoor,
-            row: usize,
-            col: usize,
-        ) -> UniquePtr<DCRTPoly>;
         fn GetTrapdoorPair(self: &DCRTTrapdoor) -> UniquePtr<RLWETrapdoorPair>;
 
         // Generator functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,6 +763,7 @@ pub mod ffi
         fn GetMatrixFromFs(n: u32, size: usize, k_res: usize, path: &String) -> UniquePtr<Matrix>;
         fn SetMatrixElement(matrix: Pin<&mut Matrix>, row: usize, col: usize, element: &DCRTPoly);
         fn GetMatrixElement(matrix: &Matrix, row: usize, col: usize) -> UniquePtr<DCRTPoly>;
+        fn GetMatrixElementUnsafe(matrix: Pin<&mut Matrix>, row: usize, col: usize) -> UniquePtr<DCRTPoly>;
         fn GetMatrixRows(matrix: &Matrix) -> usize;
         fn GetMatrixCols(matrix: &Matrix) -> usize;
     }


### PR DESCRIPTION
Unsafe and memory efficient implementation of GetPublicMatrixElement that no longer performs copy of the polynomial but takes ownership of that from the matrix.