### PR TITLE
`GetPublicMatrixElement` takes a mutable refrence to self

### DIFF
--- a/examples/dcrt_poly.rs
+++ b/examples/dcrt_poly.rs
@@ -86,11 +86,16 @@ fn main() {
 
     // ** gen trapdoor for a square matrix target of size 2x2 **
     let d = 2;
-    let trapdoor_output_square =
+    let mut trapdoor_output_square =
         ffi::DCRTSquareMatTrapdoorGen(n, size, k_res, d, sigma, base, false);
 
     let trapdoor_square = trapdoor_output_square.GetTrapdoorPair();
     let public_matrix_square = trapdoor_output_square.GetPublicMatrix();
+
+    let poly_0_0 = trapdoor_output_square
+        .as_mut()
+        .unwrap()
+        .GetPublicMatrixElement(0, 0);
 
     // build the target matrix by sampling a random polynomial for each element
     let mut target_matrix = ffi::MatrixGen(n, size, k_res, d, d);

--- a/src/DCRTPoly.cc
+++ b/src/DCRTPoly.cc
@@ -251,8 +251,12 @@ std::unique_ptr<DCRTPoly> GetMatrixElement(
     size_t row, 
     size_t col)
 {   
-    lbcrypto::DCRTPoly copy = matrix(row, col);
-    return std::make_unique<DCRTPoly>(std::move(copy));
+    lbcrypto::DCRTPoly& polyRef = const_cast<lbcrypto::DCRTPoly&>(matrix(row, col));
+    // Get a reference to the element in the matrix
+    // Move that element out of the matrix into the new DCRTPoly object
+    // Leave the original matrix element in a moved-from state (which is fine since you don't care about preserving the matrix)
+
+    return std::make_unique<DCRTPoly>(std::move(polyRef));
 }
 
 size_t GetMatrixRows(const Matrix& matrix)

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -20,18 +20,13 @@ std::unique_ptr<Matrix> DCRTTrapdoor::GetPublicMatrix() const
     return std::make_unique<Matrix>(m_publicMatrix);
 }
 
-std::unique_ptr<DCRTPoly> DCRTTrapdoor::GetPublicMatrixElement(size_t row, size_t col) const
+std::unique_ptr<DCRTPoly> DCRTTrapdoor::GetPublicMatrixElement(size_t row, size_t col)
 {
     if (row >= m_publicMatrix.GetRows() || col >= m_publicMatrix.GetCols()) {
         return nullptr;
     }
-    
-    lbcrypto::DCRTPoly& polyRef = const_cast<lbcrypto::DCRTPoly&>(m_publicMatrix(row, col));
-    // Get a reference to the element in the matrix
-    // Move that element out of the matrix into the new DCRTPoly object
-    // Leave the original matrix element in a moved-from state (which is fine since you don't care about preserving the matrix)
 
-    return std::make_unique<DCRTPoly>(std::move(polyRef));
+    return std::make_unique<DCRTPoly>(std::move(m_publicMatrix(row, col)));
 }
 
 // Generator functions

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -51,7 +51,6 @@ std::unique_ptr<DCRTTrapdoor> DCRTTrapdoorGen(
         balanced
     );
 
-    // measure memory usage after trapdoor generation
     size_t memoryUsageAfter = getMemoryUsageBytes();
     std::cout << "Memory usage after trapdoor generation: " << memoryUsageAfter << " bytes" << std::endl;
 
@@ -72,6 +71,9 @@ std::unique_ptr<DCRTTrapdoor> DCRTSquareMatTrapdoorGen(
 {
     auto params = std::make_shared<lbcrypto::ILDCRTParams<lbcrypto::BigInteger>>(2 * n, size, kRes);
 
+    size_t memoryUsageBefore = getMemoryUsageBytes();
+    std::cout << "Memory usage before trapdoor generation: " << memoryUsageBefore << " bytes" << std::endl;
+
     auto trapdoor = lbcrypto::RLWETrapdoorUtility<lbcrypto::DCRTPoly>::TrapdoorGenSquareMat(
         params,
         sigma,
@@ -79,6 +81,9 @@ std::unique_ptr<DCRTTrapdoor> DCRTSquareMatTrapdoorGen(
         base,
         balanced
     );
+
+    size_t memoryUsageAfter = getMemoryUsageBytes();
+    std::cout << "Memory usage after trapdoor generation: " << memoryUsageAfter << " bytes" << std::endl;
     
     return std::make_unique<DCRTTrapdoor>(
         std::move(trapdoor.first),

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -40,18 +40,12 @@ std::unique_ptr<DCRTTrapdoor> DCRTTrapdoorGen(
 {
     auto params = std::make_shared<lbcrypto::ILDCRTParams<lbcrypto::BigInteger>>(2 * n, size, kRes);
 
-    size_t memoryUsageBefore = getMemoryUsageBytes();
-    std::cout << "Memory usage before trapdoor generation: " << memoryUsageBefore << " bytes" << std::endl;
-
     auto trapdoor = lbcrypto::RLWETrapdoorUtility<lbcrypto::DCRTPoly>::TrapdoorGen(
         params,
         sigma,
         base,
         balanced
     );
-
-    size_t memoryUsageAfter = getMemoryUsageBytes();
-    std::cout << "Memory usage after trapdoor generation: " << memoryUsageAfter << " bytes" << std::endl;
 
     return std::make_unique<DCRTTrapdoor>(
         std::move(trapdoor.first),
@@ -70,9 +64,6 @@ std::unique_ptr<DCRTTrapdoor> DCRTSquareMatTrapdoorGen(
 {
     auto params = std::make_shared<lbcrypto::ILDCRTParams<lbcrypto::BigInteger>>(2 * n, size, kRes);
 
-    size_t memoryUsageBefore = getMemoryUsageBytes();
-    std::cout << "Memory usage before trapdoor generation: " << memoryUsageBefore << " bytes" << std::endl;
-
     auto trapdoor = lbcrypto::RLWETrapdoorUtility<lbcrypto::DCRTPoly>::TrapdoorGenSquareMat(
         params,
         sigma,
@@ -80,9 +71,6 @@ std::unique_ptr<DCRTTrapdoor> DCRTSquareMatTrapdoorGen(
         base,
         balanced
     );
-
-    size_t memoryUsageAfter = getMemoryUsageBytes();
-    std::cout << "Memory usage after trapdoor generation: " << memoryUsageAfter << " bytes" << std::endl;
     
     return std::make_unique<DCRTTrapdoor>(
         std::move(trapdoor.first),

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -1,7 +1,7 @@
 #include "Trapdoor.h"
 #include "Params.h"
 #include <filesystem>
-#include <mach/mach.h>
+// #include <mach/mach.h>
 
 namespace openfhe
 {
@@ -187,16 +187,16 @@ void DCRTSquareMatTrapdoorGaussSampToFs(usint n, usint k, const Matrix& publicMa
     }
 }
 
-// Function to get current memory usage in bytes
-size_t getMemoryUsageBytes() {
-    task_basic_info info;
-    mach_msg_type_number_t infoCount = TASK_BASIC_INFO_COUNT;
+// // Function to get current memory usage in bytes
+// size_t getMemoryUsageBytes() {
+//     task_basic_info info;
+//     mach_msg_type_number_t infoCount = TASK_BASIC_INFO_COUNT;
 
-    if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &infoCount) != KERN_SUCCESS)
-        return 0;
+//     if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &infoCount) != KERN_SUCCESS)
+//         return 0;
 
-    return info.resident_size;
-}
+//     return info.resident_size;
+// }
 
 
 } // openfhe

--- a/src/Trapdoor.cc
+++ b/src/Trapdoor.cc
@@ -26,8 +26,12 @@ std::unique_ptr<DCRTPoly> DCRTTrapdoor::GetPublicMatrixElement(size_t row, size_
         return nullptr;
     }
     
-    lbcrypto::DCRTPoly copy = m_publicMatrix(row, col);
-    return std::make_unique<DCRTPoly>(std::move(copy));
+    lbcrypto::DCRTPoly& polyRef = const_cast<lbcrypto::DCRTPoly&>(m_publicMatrix(row, col));
+    // Get a reference to the element in the matrix
+    // Move that element out of the matrix into the new DCRTPoly object
+    // Leave the original matrix element in a moved-from state (which is fine since you don't care about preserving the matrix)
+
+    return std::make_unique<DCRTPoly>(std::move(polyRef));
 }
 
 // Generator functions

--- a/src/Trapdoor.h
+++ b/src/Trapdoor.h
@@ -21,7 +21,7 @@ public:
 
     [[nodiscard]] std::unique_ptr<RLWETrapdoorPair> GetTrapdoorPair() const;
     [[nodiscard]] std::unique_ptr<Matrix> GetPublicMatrix() const;
-    [[nodiscard]] std::unique_ptr<DCRTPoly> GetPublicMatrixElement(size_t row, size_t col) const;
+    [[nodiscard]] std::unique_ptr<DCRTPoly> GetPublicMatrixElement(size_t row, size_t col);
 };
 
 // Generator functions

--- a/src/Trapdoor.h
+++ b/src/Trapdoor.h
@@ -83,5 +83,5 @@ void DCRTSquareMatTrapdoorGaussSampToFs(
     const rust::String& path
 );
 
-size_t getMemoryUsageBytes(); 
+// size_t getMemoryUsageBytes(); 
 } // openfhe

--- a/src/Trapdoor.h
+++ b/src/Trapdoor.h
@@ -82,4 +82,6 @@ void DCRTSquareMatTrapdoorGaussSampToFs(
     double sigma,
     const rust::String& path
 );
+
+size_t getMemoryUsageBytes(); 
 } // openfhe

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,7 +1173,7 @@ pub mod ffi
     unsafe extern "C++" {
         fn GetPublicMatrix(self: &DCRTTrapdoor) -> UniquePtr<Matrix>;
         fn GetPublicMatrixElement(
-            self: &DCRTTrapdoor,
+            self: Pin<&mut DCRTTrapdoor>,
             row: usize,
             col: usize,
         ) -> UniquePtr<DCRTPoly>;


### PR DESCRIPTION
Unsafe and memory efficient implementation of GetPublicMatrixElement that no longer performs copy of the polynomial but takes ownership of that from the matrix.