### PR TITLE
feat: `GenCRTBasis`

### DIFF
--- a/examples/dcrt_poly.rs
+++ b/examples/dcrt_poly.rs
@@ -17,6 +17,9 @@ fn main() {
     let modulus = ffi::GenModulus(n, size, k_res);
     println!("modulus: {:?}", modulus);
 
+    let moduli = ffi::GenCRTBasis(n, size, k_res);
+    println!("moduli: {:?}", moduli);
+
     let const_poly_2 = ffi::DCRTPolyGenFromConst(n, size, k_res, &val);
     // print the const_poly_2
     println!("const_poly_2: {:?}", const_poly_2);
@@ -145,20 +148,20 @@ fn main() {
 
     let syndrome_poly = ffi::DCRTPolyGenFromDug(n, size, k_res);
 
-    // Loop over each tower_idx which is taken from `size`
-    for tower_idx in 0..size {
-        // Call DCRTGaussSampGqArbBase for each tower
-        let digits =
-            ffi::DCRTGaussSampGqArbBase(&syndrome_poly, c, n, size, k_res, base, sigma, tower_idx);
+    // // Loop over each tower_idx which is taken from `size`
+    // for tower_idx in 0..size {
+    //     // Call DCRTGaussSampGqArbBase for each tower
+    //     let digits =
+    //         ffi::DCRTGaussSampGqArbBase(&syndrome_poly, c, n, size, k_res, base, sigma, tower_idx);
 
-        println!("Tower {}: Sampled {} digits", tower_idx, digits.len());
+    //     println!("Tower {}: Sampled {} digits", tower_idx, digits.len());
 
-        // Print first few digits (to avoid excessive output)
-        let display_count = std::cmp::min(10, digits.len());
-        println!(
-            "First {} digits: {:?}",
-            display_count,
-            &digits[0..display_count]
-        );
-    }
+    //     // Print first few digits (to avoid excessive output)
+    //     let display_count = std::cmp::min(10, digits.len());
+    //     println!(
+    //         "First {} digits: {:?}",
+    //         display_count,
+    //         &digits[0..display_count]
+    //     );
+    // }
 }

--- a/src/Params.cc
+++ b/src/Params.cc
@@ -43,4 +43,24 @@ rust::String GenModulus(
     auto params        = std::make_shared<lbcrypto::ILDCRTParams<lbcrypto::BigInteger>>(2 * n, size, kRes);
     return rust::String(params->GetModulus().ToString());
 }
+
+/// Return the CRT primes q_0, ... ,q_{L‑1}
+rust::Vec<rust::String> GenCRTBasis(  
+        usint n,
+        std::size_t depth,
+        std::size_t bits) {
+
+    using lbcrypto::BigInteger;
+    using lbcrypto::ILDCRTParams;
+
+    auto params = std::make_shared<ILDCRTParams<BigInteger>>(2 * n, depth, bits);
+
+    rust::Vec<rust::String> out;
+    out.reserve(params->GetParams().size());
+
+    for (const auto& tower : params->GetParams())
+        out.push_back(rust::String(tower->GetModulus().ToString()));
+
+    return out;
+}
 } // openfhe

--- a/src/Params.h
+++ b/src/Params.h
@@ -46,4 +46,6 @@ using ParamsCKKSRNS = lbcrypto::CCParams<lbcrypto::CryptoContextCKKSRNS>;
     const std::vector<std::string>& vals);
 [[nodiscard]] rust::String GenModulus(
     usint n, size_t size, size_t kRes);
+[[nodiscard]] rust::Vec<rust::String> GenCRTBasis(
+    usint n, size_t size, size_t kRes);
 } // openfhe

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1212,6 +1212,7 @@ pub mod ffi
         fn GenParamsByScheme(scheme : SCHEME)->UniquePtr<Params>;
         fn GenParamsByVectorOfString(vals : &CxxVector<CxxString>)->UniquePtr<Params>;
         fn GenModulus(n : u32, size : usize, k_res : usize)->String;
+        fn GenCRTBasis(n: u32, size: usize, k_res: usize) -> Vec<String>;
     }
 
     // ParamsBFVRNS


### PR DESCRIPTION
log example when run test 
```
modulus: "25711008708094929775747006828034861553612325113606108209640257"
moduli: ["2251799813684737", "2251799813684353", "2251799813684321", "2251799813683297"]
```